### PR TITLE
Allow .config/Module.symvers to live elsewhere, fix clumsy parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,37 +8,40 @@ expanded to better handle other architectures.
 ## Usage
 
 ```
-usage: gen_mod_headers [linux source dir] [target dir] <karch?=x86> <make directives>
+usage: gen_mod_headers [target dir] [linux source dir] <objects dir> <arch> <x-compile-prefix>
 ```
 
-Firstly, copy `.config` and `Module.symvers` into your kernel source
-directory. This files are required for external module building. If you don't
-have Module.symvers, you can generate it with a kernel build.
+Note that `<objects dir>` defaults to the linux source dir (i.e. for the usual
+case where objects are generated in the same directory as the source), and
+`arch` defaults to x86.
+
+Ensure `.config` and `Module.symvers` are in the objects directory (this can be
+the same as the source directory.) If you don't have Module.symvers, you can
+generate it with a kernel build.
 
 If you want to cross-compile, ensure you have the appropriate cross-compile
 version of gcc available. Google 'linaro cross compile' if you need to get hold
-of one.
+of one. Then specify the arch, and the prefix of the cross-compiler as shown
+above.
 
 If you're generating a typical x86 on x86 build, you can simply run something
 like:
 
 ```bash
-./gen_mod_headers ~/linux /tmp/headers
+./gen_mod_headers /tmp/headers ~/linux
 ```
 
 Where `~/linux` here is your linux source code dir, and `/tmp/headers` the
 output directory.
 
-For cross compile you should specify architecture and some make parameters, e.g.:
+For cross compile you should specify architecture and some make parameters,
+e.g.:
 
 ```bash
-./gen_mod_headers ~/linux /tmp/headers arm ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf-
+./gen_mod_headers /tmp/headers ~/linux ~/linux arm arm-linux-gnueabihf-
 ```
 
-Here we specify arm and pass the `make` parameters `ARCH=arm` and
-`CROSS_COMPILE=arm-linux-gnueabihf-` which specify the target architecture and
-the prefix for your cross-compile gcc binaries, in this example they are
-`arm-linux-gnueabihf-gcc`, `arm-linux-gnueabihf-as`, etc.
+Here we specify arm and the `arm-linux-gnueabihf-` prefix.
 
 ## Compiling against the headers
 

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -37,7 +37,7 @@ function pop()
 	popd >/dev/null
 }
 
-([ -z "$1" ] || [ -z "$2" ] || [ ! -d "$1" ] || ([ -f "$2" ] && [ ! -d "$2" ])) && usage
+[[ $# -ge 2 ]] || usage
 
 # Generate if doesn't exist.
 install -dm755 $2

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -17,7 +17,8 @@ function fatal()
 
 function usage()
 {
-	echo "usage: $(basename $0) [linux source dir] [target dir] <karch?=x86> <make directives>">&2
+	echo "usage: $(basename $0) [target dir] [linux source dir] <objects dir> <arch> <x-compile-prefix>">&2
+
 	exit 1
 }
 
@@ -39,18 +40,31 @@ function pop()
 
 [[ $# -ge 2 ]] || usage
 
-# Generate if doesn't exist.
-install -dm755 $2
+# Generate target dir if doesn't exist.
+install -dm755 $1
 
-linux_dir=$(get_full_path $1)
-target_dir=$(get_full_path $2)
-karch=${3:-x86}
+target_dir=$(get_full_path $1)
+linux_dir=$(get_full_path $2)
+# The directory containing .config and Module.symvers.
+obj_dir=$(get_full_path ${3:-$linux_dir})
+karch=${4:-x86}
+
+if [[ "$karch" != "x86" ]]; then
+	prefix=$5
+
+	[[ -n $prefix ]] || fatal "Non-x86 arch but no prefix specified."
+
+	build_opts="ARCH=$karch CROSS_COMPILE=$prefix"
+fi
+
 karch_dir="arch/$karch"
 target_karch_dir="$target_dir/$karch_dir"
-if [ "$#" -gt 3 ]; then
-    shift 3
-    make_opts="$@"
-fi
+
+[[ -f "${obj_dir}/.config" ]] || fatal "Missing kernel configuration."
+[[ -f "${obj_dir}/Module.symvers" ]] || fatal "Missing Module.symvers."
+
+# Copy in .config and Module.symvers so we can specify O=$target_dir.
+cp "${obj_dir}/.config" "${obj_dir}/Module.symvers" "$target_dir"
 
 extra_header_dirs="drivers/md net/mac80211 drivers/media/dvb-core include/config/dvb \
 drivers/media/dvb-frontends drivers/media/usb/dvb-usb drivers/media/tuners"
@@ -58,16 +72,14 @@ drivers/media/dvb-frontends drivers/media/usb/dvb-usb drivers/media/tuners"
 push_linux
 trap pop EXIT
 
-[ ! -f .config ] && fatal "Missing kernel configuration."
-[ ! -f Module.symvers ] && fatal "Missing Module.symvers."
-[ ! -d "$karch_dir" ] && fatal "Unrecognised karch: $karch"
+[[ -d "$karch_dir" ]] || fatal "Unrecognised karch: $karch"
 
 echo Running modules_prepare...
-make $make_opts modules_prepare >/dev/null
+make O="$target_dir" $build_opts modules_prepare
 
 echo Copying required files...
 
-for f in .config Makefile kernel/Makefile Module.symvers Documentation/DocBook/Makefile; do
+for f in Makefile kernel/Makefile Documentation/DocBook/Makefile; do
 	install -D -m644 "$f" "$target_dir/$f"
 done
 
@@ -88,7 +100,7 @@ for h in $(find $karch_dir -iname '*.h'); do
 	cp $h "$target_dir/$h"
 done
 
-cp -a scripts "$target_dir/scripts"
+cp -a scripts "$target_dir"
 # Don't strip binaries as only makes 200kb difference...
 
 mkdir -p "$target_karch_dir/kernel"


### PR DESCRIPTION
This allows .config/Module.symvers to live elsewhere, but defaults to the specified source directory. This makes yocto behave because it doesn't like source contamination.

Additionally, the cross-compile syntax is a lot less clunky now, you can just specific arch and x-compile rather than having to specify arch twice.

There's a number of other small clean ups.

**IMPORTANT: WARNING:** The syntax has changed, target directory goes first now, so be careful :)
