### PR TITLE
Copy missing tool headers and fix script/ binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,14 @@
 
 Generates kernel module headers from linux source.
 
-This is based on the [arch linux script][arch-script] which does the same task,
-expanded to better handle other architectures.
+This is based on the [arch linux script][arch-script] which performs the same
+task. We expand it to better handle cross-compiling to other architectures.
 
 ## Usage
 
 ```
-usage: gen_mod_headers [target dir] [linux source dir] <objects dir> <arch> <x-compile-prefix>
+usage: gen_mod_headers [target dir] [linux source dir] [objects dir] <arch> <x-compile-prefix>
 ```
-
-Note that `<objects dir>` defaults to the linux source dir (i.e. for the usual
-case where objects are generated in the same directory as the source), and
-`arch` defaults to x86.
 
 Ensure `.config` and `Module.symvers` are in the objects directory (this can be
 the same as the source directory.) If you don't have Module.symvers, you can
@@ -28,20 +24,22 @@ If you're generating a typical x86 on x86 build, you can simply run something
 like:
 
 ```bash
-./gen_mod_headers /tmp/headers ~/linux
+./gen_mod_headers /tmp/headers ~/kerndev/kernels/linux ~/kerndev/linux-obj
 ```
 
-Where `~/linux` here is your linux source code dir, and `/tmp/headers` the
-output directory.
+Where `/tmp/headers` is the desired output directory, `~/kerndev/kernels/linux`
+is your linux source code dir, and `~/kerndev/linux-obj` contains `.config`
+and `Module.symvers`.
 
-For cross compile you should specify architecture and some make parameters,
-e.g.:
+For cross compile you need to specify architecture and the prefix for your
+cross-compiler binaries, e.g.:
 
 ```bash
-./gen_mod_headers /tmp/headers ~/linux ~/linux arm arm-linux-gnueabihf-
+./gen_mod_headers /tmp/headers ~/kerndev/kernels/linux-arm ~/kerndev/linux-arm-obj arm arm-linux-gnueabihf-
 ```
 
-Here we specify arm and the `arm-linux-gnueabihf-` prefix.
+__IMPORTANT:__ Note that the script will generate headers that can only be used
+to compile modules on the target architecture.
 
 ## Compiling against the headers
 

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -84,6 +84,11 @@ make O="$target_dir" $build_opts modules_prepare
 
 echo Copying required files...
 
+# Move host arch script binaries so we can fix them up later. We don't want to
+# keep host binaries in place when we copy in source, we'll compile target arch
+# versions later.
+mv "$target_dir"/scripts "$target_dir"/xscripts
+
 for f in Makefile kernel/Makefile Documentation/DocBook/Makefile; do
 	install -D -m644 "$f" "$target_dir/$f"
 done
@@ -139,5 +144,42 @@ for f in $(find . -name "Kconfig*"); do
 	mkdir -p "$target_dir/$(dirname $f)"
 	cp $f "$target_dir/$f"
 done
+
+echo Fixing up script binaries...
+
+push "$target_dir"
+
+# Make some backups so we can restore sanity after we're done.
+cp scripts/basic/Makefile .backup.basic.Makefile
+cp scripts/Kbuild.include .backup.kbuild.Makefile.include
+cp scripts/Makefile.build .backup.Makefile.build
+cp scripts/mod/Makefile .backup.mod.Makefile
+cp scripts/kconfig/Makefile .backup.kconfig.Makefile
+
+# Fixup Makefile's so they reference our host arch binaries in xscripts.
+# We only need a few fixups since we're only building scripts here.
+sed -i 's|$(obj)/fixdep|x$(obj)/fixdep|' scripts/basic/Makefile
+sed -i 's|scripts/basic/fixdep|xscripts/basic/fixdep|' scripts/Kbuild.include
+sed -i 's|scripts/basic/fixdep|xscripts/basic/fixdep|' scripts/Makefile.build
+sed -i 's|$(obj)/mk_elfconfig|x$(obj)/mk_elfconfig|' scripts/mod/Makefile
+sed -i 's|$(obj)/conf|x$(obj)/conf|' scripts/kconfig/Makefile
+
+echo Building script binaries for target arch...
+
+make HOSTCC=${prefix}gcc $build_opts scripts/
+
+echo Cleaning up directory...
+
+# Reinstate pristine Makefile's.
+mv .backup.basic.Makefile scripts/basic/Makefile
+mv .backup.kbuild.Makefile.include scripts/Kbuild.include
+mv .backup.Makefile.build scripts/Makefile.build
+mv .backup.mod.Makefile scripts/mod/Makefile
+mv .backup.kconfig.Makefile scripts/kconfig/Makefile
+
+# Clean up host script bins.
+rm -rf xscripts
+
+pop
 
 echo Done!

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -17,7 +17,7 @@ function fatal()
 
 function usage()
 {
-	echo "usage: $(basename $0) [target dir] [linux source dir] <objects dir> <arch> <x-compile-prefix>">&2
+	echo "usage: $(basename $0) [target dir] [linux source dir] [objects dir] <arch> <x-compile-prefix>">&2
 
 	exit 1
 }
@@ -43,7 +43,7 @@ function pop()
 	popd >/dev/null
 }
 
-[[ $# -ge 2 ]] || usage
+[[ $# -ge 3 ]] || usage
 
 # Generate target dir if doesn't exist.
 install -dm755 $1
@@ -51,7 +51,7 @@ install -dm755 $1
 target_dir=$(get_full_path $1)
 linux_dir=$(get_full_path $2)
 # The directory containing .config and Module.symvers.
-obj_dir=$(get_full_path ${3:-$linux_dir})
+obj_dir=$(get_full_path $3)
 karch=${4:-x86}
 
 if [[ "$karch" != "x86" ]]; then

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -84,10 +84,12 @@ make O="$target_dir" $build_opts modules_prepare
 
 echo Copying required files...
 
-# Move host arch script binaries so we can fix them up later. We don't want to
-# keep host binaries in place when we copy in source, we'll compile target arch
-# versions later.
-mv "$target_dir"/scripts "$target_dir"/xscripts
+if [[ -n "$prefix" ]]; then
+	# Move host arch script binaries so we can fix them up later. We don't want to
+	# keep host binaries in place when we copy in source, we'll compile target arch
+	# versions later.
+	mv "$target_dir"/scripts "$target_dir"/xscripts
+fi
 
 for f in Makefile kernel/Makefile Documentation/DocBook/Makefile; do
 	install -D -m644 "$f" "$target_dir/$f"
@@ -145,41 +147,43 @@ for f in $(find . -name "Kconfig*"); do
 	cp $f "$target_dir/$f"
 done
 
-echo Fixing up script binaries...
+if [[ -n "$prefix" ]]; then
+	echo Fixing up script binaries...
 
-push "$target_dir"
+	push "$target_dir"
 
-# Make some backups so we can restore sanity after we're done.
-cp scripts/basic/Makefile .backup.basic.Makefile
-cp scripts/Kbuild.include .backup.kbuild.Makefile.include
-cp scripts/Makefile.build .backup.Makefile.build
-cp scripts/mod/Makefile .backup.mod.Makefile
-cp scripts/kconfig/Makefile .backup.kconfig.Makefile
+	# Make some backups so we can restore sanity after we're done.
+	cp scripts/basic/Makefile .backup.basic.Makefile
+	cp scripts/Kbuild.include .backup.kbuild.Makefile.include
+	cp scripts/Makefile.build .backup.Makefile.build
+	cp scripts/mod/Makefile .backup.mod.Makefile
+	cp scripts/kconfig/Makefile .backup.kconfig.Makefile
 
-# Fixup Makefile's so they reference our host arch binaries in xscripts.
-# We only need a few fixups since we're only building scripts here.
-sed -i 's|$(obj)/fixdep|x$(obj)/fixdep|' scripts/basic/Makefile
-sed -i 's|scripts/basic/fixdep|xscripts/basic/fixdep|' scripts/Kbuild.include
-sed -i 's|scripts/basic/fixdep|xscripts/basic/fixdep|' scripts/Makefile.build
-sed -i 's|$(obj)/mk_elfconfig|x$(obj)/mk_elfconfig|' scripts/mod/Makefile
-sed -i 's|$(obj)/conf|x$(obj)/conf|' scripts/kconfig/Makefile
+	# Fixup Makefile's so they reference our host arch binaries in xscripts.
+	# We only need a few fixups since we're only building scripts here.
+	sed -i 's|$(obj)/fixdep|x$(obj)/fixdep|' scripts/basic/Makefile
+	sed -i 's|scripts/basic/fixdep|xscripts/basic/fixdep|' scripts/Kbuild.include
+	sed -i 's|scripts/basic/fixdep|xscripts/basic/fixdep|' scripts/Makefile.build
+	sed -i 's|$(obj)/mk_elfconfig|x$(obj)/mk_elfconfig|' scripts/mod/Makefile
+	sed -i 's|$(obj)/conf|x$(obj)/conf|' scripts/kconfig/Makefile
 
-echo Building script binaries for target arch...
+	echo Building script binaries for target arch...
 
-make HOSTCC=${prefix}gcc $build_opts scripts/
+	make HOSTCC=${prefix}gcc $build_opts scripts/
 
-echo Cleaning up directory...
+	echo Cleaning up directory...
 
-# Reinstate pristine Makefile's.
-mv .backup.basic.Makefile scripts/basic/Makefile
-mv .backup.kbuild.Makefile.include scripts/Kbuild.include
-mv .backup.Makefile.build scripts/Makefile.build
-mv .backup.mod.Makefile scripts/mod/Makefile
-mv .backup.kconfig.Makefile scripts/kconfig/Makefile
+	# Reinstate pristine Makefile's.
+	mv .backup.basic.Makefile scripts/basic/Makefile
+	mv .backup.kbuild.Makefile.include scripts/Kbuild.include
+	mv .backup.Makefile.build scripts/Makefile.build
+	mv .backup.mod.Makefile scripts/mod/Makefile
+	mv .backup.kconfig.Makefile scripts/kconfig/Makefile
 
-# Clean up host script bins.
-rm -rf xscripts
+	# Clean up host script bins.
+	rm -rf xscripts
 
-pop
+	pop
+fi
 
 echo Done!

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -95,10 +95,15 @@ done
 
 mkdir -p "$target_karch_dir"
 cp -a "$karch_dir/include" "$target_karch_dir"
+cp -a "$karch_dir/tools" "$target_karch_dir"
 for h in $(find $karch_dir -iname '*.h'); do
 	mkdir -p "$target_dir/$(dirname $h)"
 	cp $h "$target_dir/$h"
 done
+
+# Copy over tools include as some builds require this.
+mkdir -p "$target_dir/tools"
+cp -a tools/include "$target_dir/tools"
 
 cp -a scripts "$target_dir"
 # Don't strip binaries as only makes 200kb difference...

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -28,9 +28,14 @@ function get_full_path()
 	echo "$( cd "$1" ; pwd -P )"
 }
 
+function push()
+{
+	pushd $@ >/dev/null
+}
+
 function push_linux()
 {
-	pushd $linux_dir >/dev/null
+	push $linux_dir
 }
 
 function pop()


### PR DESCRIPTION
Fixes #3.
## Add missing tool headers

`arch/<arch>/tools` is a small directory that the `scripts` build requires and additionally might be required by kernel module builds. `tools/include/...` is definitely required and has actively broken a user's kernel build so we include this also (but not all of `tools/...`  as that code is 15MiB in size.)
## Add workaround to generate script/ binaries in target arch

If you compile without any special provisions binaries in this directory will be host arch binaries.

If you attempt to force matters by setting HOSTCC, you face the issue that certain of the generated binaries need to be run to generate other binaries, and a catch-22 emerges.

The solution implemented here is to build as normal, then move the script binaries to the 'xscripts' directory. When the module build environment is established, Makefile's that define what scripts are run are backed up then adjusted to run binaries from xscripts, then the scripts directory is built to generate binaries for the target architecture. Once this is complete the Makefiles are made pristine again and xscripts is removed.
