### PR TITLE
Fix bug with `prefix` env var assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.0.4
+
+* Fix bug whereby if the `prefix` env var was set in the host it'd cause
+  weirdness in the scripts/ bins dance.
+
 ## v0.0.3
 
 * Updated script to correctly generate `scripts/` binaries for the _target_

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -55,6 +55,7 @@ obj_dir=$(get_full_path $3)
 karch=${4:-x86}
 prefix=$5
 
+# FIXME: We assume host arch == x86.
 if [[ "$karch" != "x86" ]]; then
 	[[ -n $prefix ]] || fatal "Non-x86 arch but no prefix specified."
 

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -53,10 +53,9 @@ linux_dir=$(get_full_path $2)
 # The directory containing .config and Module.symvers.
 obj_dir=$(get_full_path $3)
 karch=${4:-x86}
+prefix=$5
 
 if [[ "$karch" != "x86" ]]; then
-	prefix=$5
-
 	[[ -n $prefix ]] || fatal "Non-x86 arch but no prefix specified."
 
 	build_opts="ARCH=$karch CROSS_COMPILE=$prefix"


### PR DESCRIPTION
If it is set in the host environment already we can end up with weirdness when we check to see if we need to do the scripts/ bins fixup dance.
