### PR TITLE
Add option to customise cross-compiler on scripts/ bins build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.0.5
+
+* Add parameter to allow use of custom cross-compiler when building `scripts/`
+  binaries.
+
 ## v0.0.4
 
 * Fix bug whereby if the `prefix` env var was set in the host it'd cause

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ task. We expand it to better handle cross-compiling to other architectures.
 ## Usage
 
 ```
-usage: gen_mod_headers [target dir] [linux source dir] [objects dir] <arch> <x-compile-prefix>
+usage: gen_mod_headers [target dir] [linux source dir] [objects dir] <arch> <x-compile-prefix> <customcc>
 ```
 
 Ensure `.config` and `Module.symvers` are in the objects directory (this can be
@@ -40,6 +40,11 @@ cross-compiler binaries, e.g.:
 
 __IMPORTANT:__ Note that the script will generate headers that can only be used
 to compile modules on the target architecture.
+
+### Advanced
+
+If you need to use a specific custom cross-compiler when building binaries in
+the `scripts/` directory, set `customcc` accordingly.
 
 ## Compiling against the headers
 

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -17,7 +17,7 @@ function fatal()
 
 function usage()
 {
-	echo "usage: $(basename $0) [target dir] [linux source dir] [objects dir] <arch> <x-compile-prefix>">&2
+	echo "usage: $(basename $0) [target dir] [linux source dir] [objects dir] <arch> <x-compile-prefix> <customcc>">&2
 
 	exit 1
 }
@@ -54,6 +54,7 @@ linux_dir=$(get_full_path $2)
 obj_dir=$(get_full_path $3)
 karch=${4:-x86}
 prefix=$5
+hostcc="${6:-${prefix}gcc}"
 
 # FIXME: We assume host arch == x86.
 if [[ "$karch" != "x86" ]]; then
@@ -169,7 +170,7 @@ if [[ -n "$prefix" ]]; then
 
 	echo Building script binaries for target arch...
 
-	make HOSTCC=${prefix}gcc $build_opts scripts/
+	make HOSTCC="$hostcc" $build_opts scripts/
 
 	echo Cleaning up directory...
 


### PR DESCRIPTION
Yocto has a very custom configuration for its cross-compiler so `${prefix}gcc` won't do when compiling files that require system headers/libraries. In order to allow this to be specified, make the `HOSTCC=` variable customisable.
