### PR TITLE
Skip dance x86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.6
+
+* Skip the whole scripts/ bins dance if x86.
+
 ## v0.0.5
 
 * Add parameter to allow use of custom cross-compiler when building `scripts/`

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -57,7 +57,10 @@ prefix=$5
 hostcc="${6:-${prefix}gcc}"
 
 # FIXME: We assume host arch == x86.
-if [[ "$karch" != "x86" ]]; then
+if [[ "$karch" == "x86" ]]; then
+	# We don't want to do any of the scripts/ bins dance if we're x86.
+	unset prefix
+else
 	[[ -n $prefix ]] || fatal "Non-x86 arch but no prefix specified."
 
 	build_opts="ARCH=$karch CROSS_COMPILE=$prefix"


### PR DESCRIPTION
Clear prefix env var if x86 so we can skip the `scripts/` bins dance when we don't need to do it.
