### PR TITLE
Fix x86 cross-compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.6
+
+* Add ability to cross-compile x86 to x86.
+
 ## v0.0.5
 
 * Add parameter to allow use of custom cross-compiler when building `scripts/`

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -59,9 +59,11 @@ hostcc="${6:-${prefix}gcc}"
 # FIXME: We assume host arch == x86.
 if [[ "$karch" != "x86" ]]; then
 	[[ -n $prefix ]] || fatal "Non-x86 arch but no prefix specified."
-
-	build_opts="ARCH=$karch CROSS_COMPILE=$prefix"
 fi
+
+build_opts=""
+# Regardless of target arch, if a prefix is specified we are cross-compiling.
+[[ -z "$prefix" ]] || build_opts="ARCH=$karch CROSS_COMPILE=$prefix"
 
 karch_dir="arch/$karch"
 target_karch_dir="$target_dir/$karch_dir"

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -108,6 +108,7 @@ for d in include $extra_header_dirs; do
 	[ -d "$d" ] && mkdir -p "$target_dir/$d"
 done
 
+# Configure arch/<arch> directory.
 mkdir -p "$target_karch_dir"
 cp -a "$karch_dir/include" "$target_karch_dir"
 cp -a "$karch_dir/tools" "$target_karch_dir"

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -117,6 +117,11 @@ for f in $(find $karch_dir -iname '*.h' -o -name 'Makefile' -o -iname '*.tbl' -o
 	cp $f "$target_dir/$f"
 done
 
+for f in $(find security -iname '*.h'); do
+	mkdir -p "$target_dir/$(dirname $f)"
+	cp $f "$target_dir/$f"
+done
+
 # Copy over tools include as some builds require this.
 mkdir -p "$target_dir/tools"
 cp -a tools/include "$target_dir/tools"

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -112,9 +112,9 @@ done
 mkdir -p "$target_karch_dir"
 cp -a "$karch_dir/include" "$target_karch_dir"
 cp -a "$karch_dir/tools" "$target_karch_dir"
-for h in $(find $karch_dir -iname '*.h'); do
-	mkdir -p "$target_dir/$(dirname $h)"
-	cp $h "$target_dir/$h"
+for f in $(find $karch_dir -iname '*.h' -o -name 'Makefile' -o -iname '*.tbl' -o -iname '*.sh'); do
+	mkdir -p "$target_dir/$(dirname $f)"
+	cp $f "$target_dir/$f"
 done
 
 # Copy over tools include as some builds require this.


### PR DESCRIPTION
Allow for x86 to x86 cross-compile so, at least theoretically, we should be able to build 32-bit `scripts/` bins and other files on 64-bit host.
