### PR TITLE
Fix arm64 build - only copy dirs when needed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.7
+
+* Only copy directories if they exist.
+
 ## v0.0.6
 
 * Add ability to cross-compile x86 to x86.

--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -43,6 +43,16 @@ function pop()
 	popd >/dev/null
 }
 
+function copy_dir()
+{
+	from="$1"
+	to="$2"
+
+	if [[ -d "$from" ]]; then
+		cp -a "$from" "$to"
+	fi
+}
+
 [[ $# -ge 3 ]] || usage
 
 # Generate target dir if doesn't exist.
@@ -110,8 +120,8 @@ done
 
 # Configure arch/<arch> directory.
 mkdir -p "$target_karch_dir"
-cp -a "$karch_dir/include" "$target_karch_dir"
-cp -a "$karch_dir/tools" "$target_karch_dir"
+copy_dir "$karch_dir/include" "$target_karch_dir"
+copy_dir "$karch_dir/tools" "$target_karch_dir"
 for f in $(find $karch_dir -iname '*.h' -o -name 'Makefile' -o -iname '*.tbl' -o -iname '*.sh'); do
 	mkdir -p "$target_dir/$(dirname $f)"
 	cp $f "$target_dir/$f"
@@ -124,9 +134,9 @@ done
 
 # Copy over tools include as some builds require this.
 mkdir -p "$target_dir/tools"
-cp -a tools/include "$target_dir/tools"
+copy_dir tools/include "$target_dir/tools"
 
-cp -a scripts "$target_dir"
+copy_dir scripts "$target_dir"
 # Don't strip binaries as only makes 200kb difference...
 
 mkdir -p "$target_karch_dir/kernel"


### PR DESCRIPTION
Only copy a directory if it exists.
