### PR TITLE
gen_mod_headers: Pass HOSTCC to make modules_prepare too

### DIFF
--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -102,7 +102,7 @@ trap pop EXIT
 [[ -d "$karch_dir" ]] || fatal "Unrecognised karch: $karch"
 
 echo Running modules_prepare...
-make O="$target_dir" $build_opts modules_prepare
+make HOSTCC="$hostcc" O="$target_dir" $build_opts modules_prepare
 
 echo Copying required files...
 


### PR DESCRIPTION
On newer linux versions, modules_prepare compiles some tools (like
extract-cert) which need flags like sysroot paths, ld flags and so on.
This change lets a builder inject these flags in HOSTCC.

Change-type: patch
Signed-off-by: Andrei Gherzan <andrei@resin.io>