### PR TITLE
gen_mod_headers: Use correct target for re-building the scripts

### DIFF
--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -231,7 +231,7 @@ if [[ -n "$prefix" ]]; then
 	fi
 
 	echo Building script binaries for target arch...
-	make HOSTCC="$hostcc" $build_opts scripts/
+	make HOSTCC="$hostcc" $build_opts scripts
 
 	# copy the native fixdep back
 	if [[ -e tools/build/fixdep_native ]]; then


### PR DESCRIPTION
At the end of the kernel header generation step we run make again
on the scripts in order to have them generated for the target
architecture. However, the scripts target was wrongfully specified
which had the side-effect of regenerating the entire kernel header
archive and on one architecture we noticed that utsrelease.h had
incorrect contents after this regeneration. (there may have been
other unwanted side-effects but they were not discovered at this point)

Signed-off-by: Florin Sarbu <florin@balena.io>