### PR TITLE
gen_mod_headers: Pass LD to objtool

### DIFF
--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -226,7 +226,7 @@ if [[ -n "$prefix" ]]; then
 	sed -i 's|$(obj)/conf|x$(obj)/conf|' scripts/kconfig/Makefile
 
 	echo Building script binaries for target arch...
-	make HOSTCC="$hostcc" $build_opts scripts
+	make HOSTCC="$hostcc" HOSTLD="$LD" $build_opts scripts
 
 	if [[ -e xtools/objtool/fixdep ]]; then
 	    if [[ -e tools/build/Makefile ]]; then
@@ -241,13 +241,13 @@ if [[ -n "$prefix" ]]; then
 	    fi
 
 	    echo Building objtool for target
-	    make -C tools/objtool HOSTCC="$hostcc" $build_opts
+	    make -C tools/objtool HOSTCC="$hostcc" HOSTLD="$LD" $build_opts
 	    rm -rf tools/objtool/fixdep tools/objtool/fixdep_temp
 	    mv .backup.tools.build.Makefile tools/build/Makefile
 
             if [[ -e tools/build/Makefile ]]; then
 	        echo Building fixdep for target
-    	        make -C tools/build HOSTCC="$hostcc" $build_opts
+	        make -C tools/build HOSTCC="$hostcc" HOSTLD="$LD" $build_opts
 
     	        # move the target fixdep to the expected location
     	        mv tools/build/fixdep tools/objtool/


### PR DESCRIPTION
We've been using the host LD instead of the yocto builds LD to link
these binaries. This got hightlighted with warrior work that bumped
binutils to 2.32 which fixed a bug that highlighted the issue.

Change-type: patch
Changelog-entry: Pass LD to objtool
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>