### PR TITLE
gen_mod_headers: Also package module.lds for arm 64 bits

### DIFF
--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -197,6 +197,11 @@ if [ "$karch" = "arm64" ] && [ -f "$karch_dir/include/asm/opcodes.h" ]; then
 	copy_mkdir "$target_dir" "./arch/arm/include/asm/opcodes.h"
 fi
 
+# copy module.lds if it exists
+if [ "$karch" = "arm64" ] && [ -f "arch/arm64/kernel/module.lds" ]; then
+	copy_mkdir "$target_dir" "./arch/arm64/kernel/module.lds"
+fi
+
 if [[ -n "$prefix" ]]; then
 	echo Fixing up script binaries...
 


### PR DESCRIPTION
This fixes the following build error on rpi3 64 bits:
 ld: cannot open linker script file
./arch/arm64/kernel/module.lds: No such file or directory

Change-type:patch
Changelog-entry: Package module.lds for arm 64 bits
Signed-off-by: Florin Sarbu <florin@balena.io>