### PR TITLE
gen_mod_headers: Use native fixdep for target objtool on kernel 5.0.3

### DIFF
--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -238,6 +238,8 @@ if [[ -n "$prefix" ]]; then
 
 		# trying to apply the previous sed in context of 4.18 kernel
 		sed -i 's|$(QUIET_LINK)$(HOSTCC) $(HOSTLDFLAGS) -o $@ $<|$(QUIET_LINK)$(HOSTCC) $(HOSTLDFLAGS) -o fixdep_temp $<|' tools/build/Makefile
+		# trying to apply the previous sed in context of 5.0.3 kernel
+		sed -i 's|$(QUIET_LINK)$(HOSTCC) $(KBUILD_HOSTLDFLAGS) -o $@ $<|$(QUIET_LINK)$(HOSTCC) $(KBUILD_HOSTLDFLAGS) -o fixdep_temp $<|' tools/build/Makefile
 	    fi
 
 	    echo Building objtool for target


### PR DESCRIPTION
We need to make sure we use the cross fixdep binary when compiling the
target objtool in the context of kernel 5.0.3 which has a changed
Makefile.

Change-type: patch
Changelog-entry: Use native fixdep for target objtool on kernel 5.0.3
Signed-off-by: Florin Sarbu <florin@balena.io>