### PR TITLE
gen_mod_headers: Fix target modpost not being built on kernel 5.0.3

### DIFF
--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -227,6 +227,8 @@ if [[ -n "$prefix" ]]; then
 
 	echo Building script binaries for target arch...
 	make HOSTCC="$hostcc" HOSTLD="$LD" $build_opts scripts
+	# for kernel 5.0.3 the following also builds scripts/mod which was removed from "make scripts" (see https://patchwork.kernel.org/patch/10690901/)
+	make HOSTCC="$hostcc" HOSTLD="$LD" $build_opts prepare0
 
 	if [[ -e xtools/objtool/fixdep ]]; then
 	    if [[ -e tools/build/Makefile ]]; then


### PR DESCRIPTION
On newer kernels (it was observed on 5.0.3) the binaries from
scripts/mod are not built by doing "make scripts" anymore.
(see https://patchwork.kernel.org/patch/10690901/)
Instead, building of the scripts/mod has been moved to the
prepare0 target.

Changelog-entry: Fix target modpost not being built on kernel 5.0.3
Signed-off-by: Florin Sarbu <florin@balena.io>