### PR TITLE
gen_mod_headers: Make sure correct utsrelease.h is packaged

### DIFF
--- a/gen_mod_headers
+++ b/gen_mod_headers
@@ -228,7 +228,10 @@ if [[ -n "$prefix" ]]; then
 	echo Building script binaries for target arch...
 	make HOSTCC="$hostcc" HOSTLD="$LD" $build_opts scripts
 	# for kernel 5.0.3 the following also builds scripts/mod which was removed from "make scripts" (see https://patchwork.kernel.org/patch/10690901/)
+	# (because the following make alters utsrelease.h at least on some machines - Variscite mx8m - let's make a backup and restore it after)
+	cp include/generated/utsrelease.h include/generated/utsrelease.h.bkp
 	make HOSTCC="$hostcc" HOSTLD="$LD" $build_opts prepare0
+	mv include/generated/utsrelease.h.bkp include/generated/utsrelease.h
 
 	if [[ -e xtools/objtool/fixdep ]]; then
 	    if [[ -e tools/build/Makefile ]]; then


### PR DESCRIPTION
It was observed that on some machines (Variscite mx8m) the
utsrelease.h header is regenerated with incomplete content when
running "make prepare0" (utsrelease.h will not contain the short
git revision although the kernel's abiversion includes it and
as such the external modules built using this utsrelease.h header
will fail to load because of this mismatch).

Change-type: patch
Changelog-entry: Make sure correct utsrelease.h is packaged
Signed-off-by: Florin Sarbu <florin@balena.io>